### PR TITLE
add some clarifications wrt editor's command line

### DIFF
--- a/src/default_editor.py
+++ b/src/default_editor.py
@@ -6,74 +6,85 @@ from src.goodies import print_warning
 
 OS = {
     "macOS": {
-        "QUERY_DEFAULTS_COMMAND": [
+        "QUERY_ALL_DEFAULTS_COMMAND": [
             "defaults",
             "read",
             "com.apple.LaunchServices/com.apple.launchservices.secure",
             "LSHandlers",
         ],
-        "REGEX": r'(?ms)\s*\{\s*LSHandlerContentType = "public\.plain-text";\s*LSHandlerPreferredVersions =\s*\{\s*LSHandlerRoleAll = "-";\s*\};\s*LSHandlerRoleAll = "([\w.]+)";',
-        "DEFAULT_COMMAND": [
-            "open",
-            "-neW",
-        ],
-        "EDITOR_COMMAND": {
+        "EXTRACT_EDITOR": r'(?ms)\s*\{\s*LSHandlerContentType = "public\.plain-text";\s*LSHandlerPreferredVersions =\s*\{\s*LSHandlerRoleAll = "-";\s*\};\s*LSHandlerRoleAll = "([\w.]+)";',
+        "DEFAULT_EDITOR_COMMAND": {
             "com.microsoft.vscode": ["code", "-w"],
             "com.sublimetext.3": ["subl", "-w"],
         },  # TODO: add different versions of Sublime Text
+        "FALLBACK_EDITOR_COMMAND": [
+            "open",
+            "-n",  # open a new instance of the application even if one is already running
+            "-e",  # open with TextEdit
+            "-W",  # block until the **application** is closed (even if it was already running).
+            #        This is far from ideal, but there is currently no per-window way to check
+        ],
     },
     "Linux": {
-        "QUERY_DEFAULTS_COMMAND": [
+        "QUERY_ALL_DEFAULTS_COMMAND": [
             "xdg-mime",
             "query",
             "default",
             "text/plain",
         ],
-        "REGEX": r"^(.*)\.desktop$",
-        "DEFAULT_COMMAND": ["open", "-w"],
-        "EDITOR_COMMAND": {
-            "code": ["code", "-w"],
+        "EXTRACT_EDITOR": r"^(.*)\.desktop$",
+        "DEFAULT_EDITOR_COMMAND": {
+            "code": [
+                "code",
+                "-w", # wait for the file to be closed before returning
+            ],
             "sublime_text": ["subl", "-w"],
         },
+        "FALLBACK_EDITOR_COMMAND": ["open", "-w"],
     },
+    # TODO: add Windows
 }
 
 
-def get_editor_command_name(os_name: str = "") -> list:
+def get_editor_command(os_name: str = "") -> list:
     """
-    Retrieve the system's default text editor.
+    Retrieve a command launching a text editor.
 
     Args:
-        os_name: operating system's name
-            macOS and Linux (with XDG utils installed) currently supported
+        os_name: operating system's name.
+            Currently supported (see global OS dictionary):
+            - macOS
+            - Linux (with XDG utils installed)
 
     Returns:
-        The default text editor's command name for supported editors.
-        The `open -w` command for an unsupported or undefined editor.
+        A list of strings representing the command to launch the system's default text editor.
+        If no default text editor is defined, a suitable fallback command is returned.
 
     Raises:
-        UnsupportedOS Error if the os is not supported.
+        UnsupportedOSError: if the OS dictionary defines no key for the given operating system name.
     """
-    os = OS.get(os_name)
-    if not os:
-        raise UnsupportedOS("OS not yet supported.")
-    parse_output = re.compile(str(os["REGEX"])).findall  # make mypy happy
+    actual_os = OS.get(os_name)
+    if not actual_os:
+        raise UnsupportedOSError("OS not yet supported.")
+
     try:
-        result = parse_output(
-            subprocess.run(
-                list(os["QUERY_DEFAULTS_COMMAND"]),  # make mypy happy
-                encoding="utf-8",
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                check=True,
-            ).stdout
-        )
-        if result:
-            return os["EDITOR_COMMAND"][result[0]]  # type: ignore
-    except (subprocess.CalledProcessError, KeyError) as e:
+        output = subprocess.run(
+            list(actual_os["QUERY_ALL_DEFAULTS_COMMAND"]),  # make mypy happy
+            encoding="utf-8",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        ).stdout
+    except subprocess.CalledProcessError as e:
         print_warning(str(e))  # make mypy happy
-    return list(os["DEFAULT_COMMAND"])  # make mypy happy
+        output = ""  # make the following regular expression fail
+
+    default_editor_handler = re.findall(str(actual_os["EXTRACT_EDITOR"]), output)  # make mypy happy
+    if default_editor_handler:
+        return actual_os["DEFAULT_EDITOR_COMMAND"][default_editor_handler[0]]  # type: ignore
+    else:
+        return list(actual_os["FALLBACK_EDITOR_COMMAND"])  # make mypy happy
 
 
-class UnsupportedOS(Exception):
+class UnsupportedOSError(Exception):
     ...

--- a/src/edition.py
+++ b/src/edition.py
@@ -7,7 +7,7 @@ from tempfile import NamedTemporaryFile
 from typing import List
 from natsort import os_sorted  # type: ignore
 
-from src.default_editor import get_editor_command_name
+from src.default_editor import get_editor_command
 from src.user_types import Clause, Name
 
 
@@ -81,7 +81,7 @@ def run_editor(editable_file_path: Path) -> str:
     Returns:
         The text contained in editable_file_path when the user closes the editor's window.
     """
-    editor = get_editor_command_name(platform().split("-")[0]) + [str(editable_file_path)]
+    editor = get_editor_command(platform().split("-")[0]) + [str(editable_file_path)]
     subprocess.run(editor, check=True)
     return editable_file_path.read_text()
 

--- a/src/edition.py
+++ b/src/edition.py
@@ -81,8 +81,8 @@ def run_editor(editable_file_path: Path) -> str:
     Returns:
         The text contained in editable_file_path when the user closes the editor's window.
     """
-    editor = get_editor_command(platform().split("-")[0]) + [str(editable_file_path)]
-    subprocess.run(editor, check=True)
+    editor_command = get_editor_command(platform().split("-")[0]) + [str(editable_file_path)]
+    subprocess.run(editor_command, check=True)
     return editable_file_path.read_text()
 
 

--- a/test/test_default_editor.py
+++ b/test/test_default_editor.py
@@ -5,14 +5,14 @@ import context
 from src.default_editor import *
 
 
-def test_get_editor_command_name():
+def test_get_editor_command():
     os = platform().split("-")[0]
-    if os != "Linux" and os != "macOS":
-        with pytest.raises(UnsupportedOS):
-            get_editor_command_name(os)
+    if os not in ("Linux", "macOS"):
+        with pytest.raises(UnsupportedOSError):
+            get_editor_command(os)
     else:
-        result = get_editor_command_name(os)
-        assert result[0] in ("code", "subl", "open")
+        command = get_editor_command(os)
+        assert command[0] in ("code", "subl", "open")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Main changes:
- Make clear that this function returns a complete command, not a command name.
- Suffix the error class with Error.
- Tighten the exception mechanism around subprocess.run.
- Suppress the exception KeyError (is this ok?).
- Distinguish between default editor (specified by the user) and fallback editor (os-dependent).
- Rename os into actual_os to avoid a potential name clash with the os standard library.
- Add some more comments.