### PR TITLE
encapsulate the renaming functions into a class

### DIFF
--- a/src/get_editor_command.py
+++ b/src/get_editor_command.py
@@ -73,7 +73,7 @@ def get_editor_command(path: Path, platform: Optional[str] = None) -> list:
     if not os_dict:
         print_.fail(
             f"Unsupported operating system: {platform}. "
-            f"Supported operating systems are: {', '.join(OS.keys())}"
+            f"Supported operating systems are: {', '.join(OS.keys())}."
         )
         raise UnsupportedOSError(platform)
 

--- a/src/renamings.py
+++ b/src/renamings.py
@@ -7,95 +7,99 @@ from src.printer import print_
 from src.user_errors import RecoverableRenamingError
 from src.user_types import Arc
 
-LOG_DIR = Path.home() / ".suprenam"
-LOG_NAME = "previous_session.log"
 
+class Renamer:
 
-def create_new_log_file(log_path: Path = LOG_DIR / LOG_NAME):
-    """Create a log file at the specified path."""
-    # Ensure the log directory exists.
-    log_path.parent.mkdir(
-        parents=True,  # any missing parents of this path are created as needed
-        exist_ok=True,  # if the directory already exists, do not raise an exception
-    )
-    # Remove all handlers associated with the root logger object and create a NEW log file.
-    for handler in logging.root.handlers[:]:
-        logging.root.removeHandler(handler)
-    logging.basicConfig(filename=log_path, filemode="w", level=logging.DEBUG)
-    return log_path
+    LOG_DIR = Path.home() / ".suprenam"
+    LOG_NAME = "previous_session.log"
+    get_logged_arcs = re.compile(r"(?m)^\w+:\w+:SOURCE:(.+)\n\w+:\w+:TARGET:(.+)").findall
 
+    def __init__(self, log_path: Path = LOG_DIR / LOG_NAME):
+        """Create a log file at the specified path."""
+        # Ensure the log directory exists.
+        log_path.parent.mkdir(
+            parents=True,  # any missing parents of this path are created as needed
+            exist_ok=True,  # if the directory already exists, do not raise an exception
+        )
+        self.log_path = log_path
 
-def get_log_path() -> Path:
-    """Return the path to the log file."""
-    return Path(logging.getLoggerClass().root.handlers[0].baseFilename)  # type: ignore
+    def create_new_log_file(self):
+        """Remove all handlers associated with the root logger object and create a NEW log file."""
+        for handler in logging.root.handlers[:]:
+            logging.root.removeHandler(handler)
+        logging.basicConfig(filename=self.log_path, filemode="w", level=logging.DEBUG)
 
+    def perform_renamings(self, arcs: List[Arc]):
+        """
+        Perform the renamings specified by the list of arcs (source path, target path), and
+        log them one by one.
 
-def show_log_file():  # pragma: no cover
-    """Print the contents of the log file (for testing purposes only)."""
-    try:
-        log_path = get_log_path()
-        print_(f"Log file at '{log_path}':")
-        print_(log_path.read_text())
-    except FileNotFoundError as e:
-        print_.warning(f"Log file not found: {e}.")
+        Args:
+            arcs: list of couples (source_path, target_path)
+        """
+        self.create_new_log_file()
+        n = len(arcs)
+        print_(f"Renaming {n} items...")
+        try:
+            self.rename_and_log_all_files(arcs)
+            return print_.success(f"All {n} item{'s'[:n^1]} were renamed.")
+        except Exception as e:
+            logging.warning(str(e))
+            print_.fail(str(e))
+            raise RecoverableRenamingError
 
+    def rollback_renamings(self):
+        """
+        Rollback the first renaming operations.
 
-def perform_renamings(arcs: List[Arc]):
-    """
-    Perform the renamings specified by the list of arcs (source path, target path), and
-    log them one by one.
+        The inverse renaming are appended to the log file.
+        """
+        n = len(self.arcs_to_rollback)
+        print_(f"Rolling back the first {n} renaming{'s'[:n^1]}...")
+        logging.info("rollback")
+        try:
+            self.rename_and_log_all_files(self.arcs_to_rollback)
+            self.log_path.write_text("")  # no need to keep a symmetric sequence of renamings!
+            print_.success(f"All {n} item{'s'[:n^1]} renamings were rolled back.")
+        except Exception as e:
+            logging.error(f"rollback:{e}")
+            print_.fail(str(e))
+            raise
 
-    Args:
-        arcs: list of couples (source_path, target_path)
-    """
-    create_new_log_file()
+    def undo_renamings(self):
+        """Read a log file and apply the reversed renamings."""
+        try:
+            log_text = self.log_path.read_text()
+        except Exception as e:
+            print_.fail(str(e))
+            raise
+        if re.search(r"(?m)^ERROR:", log_text):
+            print_.fail("The previous rollback failed. Undoing is not possible.")
+            raise ValueError
+        arcs = []
+        for (source, target) in reversed(self.get_logged_arcs(log_text)):
+            arcs.append(Arc(Path(target), Path(source)))
+        self.perform_renamings(arcs)
 
-    # Perform the actual renaming operations.
-    n = len(arcs)
-    print_(f"Renaming {n} items...")
-    try:
-        for (i, arc) in enumerate(arcs):
-            rename_and_log_one_file(arc)
-        print_arcs(arcs)
+    def rename_and_log_all_files(self, arcs: List[Arc]):
+        self.arcs_to_rollback: List[Arc] = []
+        for (source, target) in arcs:
+            source.rename(target)
+            self.arcs_to_rollback.insert(0, Arc(target, source))
+            logging.info(f"SOURCE:{source}")
+            logging.info(f"TARGET:{target}")
+        self.print_arcs(arcs)
         print_.newline()
-        return print_.success(f"All {n} item{'s'[:n^1]} were renamed.")
-    except Exception as e:
-        logging.warning(str(e))
-        print_.fail(str(e))
 
-    # Rollback the first renaming operations.
-    print_(f"Rolling back the first {i} renaming{'s'[:i^1]}...")
-    for (source, target) in reversed(arcs[:i]):
-        rename_and_log_one_file(Arc(target, source))
-    logging.warning("Rolled back.")
-    print_.success("Rolled back.")
-    raise RecoverableRenamingError
+    def print_arcs(self, arcs: List[Arc]):
+        previous_parent = Path()
+        for (source, target) in arcs:
+            if source.parent != previous_parent:
+                print_.newline()
+                print_(f"{source.parent}")
+                previous_parent = source.parent
+            print_(f"{source.name} -> {target.name}")
 
-
-def rename_and_log_one_file(arc: Arc):
-    arc.source.rename(arc.target)
-    logging.info(f"SOURCE:{arc.source}")
-    logging.info(f"TARGET:{arc.target}")
-
-
-def undo_renamings(get_arcs=re.compile(r"(?m)^\w+:\w+:SOURCE:(.+)\n\w+:\w+:TARGET:(.+)").findall):
-    """Read a log file and apply the reversed renamings."""
-    log_path = get_log_path()
-    arcs = [Arc(Path(target), Path(source)) for (source, target) in get_arcs(log_path.read_text())]
-    n = len(arcs)
-    print_(f"Undoing the {n} renamings found in the log file...")
-    create_new_log_file()
-    for arc in reversed(arcs):
-        rename_and_log_one_file(arc)
-    print_arcs(arcs)
-    print_.newline()
-    print_.success(f"All {n} item{'s'[:n^1]} were unrenamed.")
-
-def print_arcs(arcs: List[Arc]):
-    previous_parent = Path()
-    for (source, target) in arcs:
-        if source.parent != previous_parent:
-            print_.newline()
-            print_(f"{source.parent}")
-            previous_parent = source.parent
-        print_(f"{source.name} -> {target.name}")
+    def get_log_contents(self):  # pragma: no cover
+        """get the contents of the log file (for testing purposes only)."""
+        return self.log_path.read_text().strip()

--- a/src/user_errors.py
+++ b/src/user_errors.py
@@ -1,12 +1,12 @@
 class UnsupportedOSError(Exception):
-    """
-    
-    """
+    pass
+
 
 class UnknownInodeError(ValueError):
     """
     The edited text contains an inode absent from the source text.
     """
+
 
 class TabulationError(ValueError):
     """
@@ -40,7 +40,8 @@ class DuplicatedClauseError(Exception):
     A clause (source, target) is specified more than once.
     """
 
+
 class RecoverableRenamingError(Exception):
     """
-    Raised after a successful rollback.
+    Raised after a failed renaming, with the goal of triggering a rollback.
     """

--- a/src/user_types.py
+++ b/src/user_types.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, Literal, NamedTuple, NewType
+from typing import Dict, NamedTuple, NewType
 
 Name = NewType("Name", str)
 

--- a/test/interactive_demo.py
+++ b/test/interactive_demo.py
@@ -6,7 +6,7 @@ sys.path[0:0] = ["."]
 
 from src.goodies import rm_tree
 from src.suprenam import run_on_path_list
-from src.renamings import show_log_file, undo_renamings
+from src.renamings import Renamer
 
 
 playground = Path("test/playground")
@@ -45,14 +45,16 @@ try:
 except Exception as e:
     print(f"Something else went wrong: {e}.")
 
+renamer = Renamer()
+
 input("Press Enter to show the log file...")
-show_log_file()
+print(renamer.get_log_contents())
 
 input("Press Enter to revert the previous renamings...")
-undo_renamings()
+renamer.undo_renamings()
 
 input("Press Enter to show the log file...")
-show_log_file()
+print(renamer.get_log_contents())
 
 input("Press Enter to erase the playground...")
 rm_tree(playground)

--- a/test/test_renamings.py
+++ b/test/test_renamings.py
@@ -8,54 +8,212 @@ from src.goodies import rm_tree
 import pytest
 
 
-def test_happy_path():
-    """Test the case where all the arcs succeed."""
+def test_rename():
+    """All renamings succeed."""
+    renamer = Renamer()
     base = Path("test") / "happy_path"
     rm_tree(base)
     base.mkdir()
     arcs = [
+        Arc(base / "source_0", base / "target_0"),
         Arc(base / "source_1", base / "target_1"),
         Arc(base / "source_2", base / "target_2"),
-        Arc(base / "source_3", base / "target_3"),
     ]
     for arc in arcs:
         arc.source.touch()
-    perform_renamings(arcs)
-    try:
-        assert set(base.iterdir()) == set(arc.target for arc in arcs)
-        undo_renamings()
-        print(set(arc.source for arc in arcs))
-        print(set(base.iterdir()))
-        assert set(base.iterdir()) == set(arc.source for arc in arcs)
-    finally:
-        rm_tree(base)
+    renamer.perform_renamings(arcs)
+    assert set(base.iterdir()) == set(arc.target for arc in arcs)
+    assert renamer.get_log_contents() == "\n".join([
+        "INFO:root:SOURCE:test/happy_path/source_0",
+        "INFO:root:TARGET:test/happy_path/target_0",
+        "INFO:root:SOURCE:test/happy_path/source_1",
+        "INFO:root:TARGET:test/happy_path/target_1",
+        "INFO:root:SOURCE:test/happy_path/source_2",
+        "INFO:root:TARGET:test/happy_path/target_2",
+    ])
+    rm_tree(base)
 
 
-def test_rollback_path():
-    """Test the case where a renaming fails, and the previous ones are reverted."""
+def test_rename_and_undo():
+    """All renamings succeed, then are successfully undone."""
+    renamer = Renamer()
+    base = Path("test") / "happy_path"
+    rm_tree(base)
+    base.mkdir()
+    arcs = [
+        Arc(base / "source_0", base / "target_0"),
+        Arc(base / "source_1", base / "target_1"),
+        Arc(base / "source_2", base / "target_2"),
+    ]
+    for arc in arcs:
+        arc.source.touch()
+    renamer.perform_renamings(arcs)
+    renamer.undo_renamings()
+    assert set(base.iterdir()) == set(arc.source for arc in arcs)
+    print(renamer.get_log_contents())
+    assert renamer.get_log_contents() == "\n".join([
+        "INFO:root:SOURCE:test/happy_path/target_2",
+        "INFO:root:TARGET:test/happy_path/source_2",
+        "INFO:root:SOURCE:test/happy_path/target_1",
+        "INFO:root:TARGET:test/happy_path/source_1",
+        "INFO:root:SOURCE:test/happy_path/target_0",
+        "INFO:root:TARGET:test/happy_path/source_0",
+    ])
+    rm_tree(base)
+
+
+def test_rename_and_undo_fail_after_target_deletion():
+    """All renamings succeed, but undo them fails."""
+    renamer = Renamer()
+    base = Path("test") / "happy_path"
+    rm_tree(base)
+    base.mkdir()
+    arcs = [
+        Arc(base / "source_0", base / "target_0"),
+        Arc(base / "source_1", base / "target_1"),
+        Arc(base / "source_2", base / "target_2"),
+    ]
+    for arc in arcs:
+        arc.source.touch()
+    renamer.perform_renamings(arcs)
+    assert set(base.iterdir()) == set(arc.target for arc in arcs)
+    arcs[1].target.unlink()  # delete a renamed file
+    with pytest.raises(RecoverableRenamingError):
+        renamer.undo_renamings()
+    assert set(base.iterdir()) == {
+        arcs[2].source, # correctly undone
+        arcs[0].target, # failed to be undone
+    }
+    assert renamer.get_log_contents() == "\n".join([
+        "INFO:root:SOURCE:test/happy_path/target_2",
+        "INFO:root:TARGET:test/happy_path/source_2",
+        "WARNING:root:[Errno 2] No such file or directory: 'test/happy_path/target_1' -> 'test/happy_path/source_1'",
+    ])
+    renamer.rollback_renamings()
+    print(set(base.iterdir()))
+    assert set(base.iterdir()) == {
+        arcs[2].target, # correctly undone
+        arcs[0].target, # failed to be undone
+    }
+    assert renamer.get_log_contents() == ""
+    rm_tree(base)
+
+
+def test_rename_and_undo_fail_after_log_file_deletion():
+    """All renamings succeed, but undo them fails."""
+    renamer = Renamer()
+    base = Path("test") / "happy_path"
+    rm_tree(base)
+    base.mkdir()
+    arcs = [
+        Arc(base / "source_0", base / "target_0"),
+        Arc(base / "source_1", base / "target_1"),
+        Arc(base / "source_2", base / "target_2"),
+    ]
+    for arc in arcs:
+        arc.source.touch()
+    renamer.perform_renamings(arcs)
+    assert set(base.iterdir()) == set(arc.target for arc in arcs)
+    renamer.log_path.unlink()  # delete the log file
+    with pytest.raises(Exception):
+        renamer.undo_renamings()
+    assert set(base.iterdir()) == set(arc.target for arc in arcs)
+    rm_tree(base)
+
+
+def test_rename_fail_and_rollback():
+    """One renaming fails, but the previous ones are successfully rolled back."""
+    renamer = Renamer()
     base = Path("test") / "rollback_path"
     rm_tree(base)
     base.mkdir()
     arcs = [
+        Arc(base / "source_0", base / "target_0"),
         Arc(base / "source_1", base / "target_1"),
         Arc(base / "source_2", base / "target_2"),
         Arc(base / "source_3", base / "target_3"),
-        Arc(base / "source_4", base / "target_4"),
     ]
     for arc in arcs:
         arc.source.touch()
     arcs[2].source.unlink()  # delete a source
     with pytest.raises(RecoverableRenamingError):
-        perform_renamings(arcs)
-    try:
-        assert set(base.iterdir()) == {
-            base / "source_1",
-            base / "source_2",
-            base / "source_4",
-        }
-    finally:
-        rm_tree(base)
+        renamer.perform_renamings(arcs) # the renaming fails
+    renamer.rollback_renamings() # but we can roll back the previous ones
+    assert set(base.iterdir()) == {
+        base / "source_0", # rolled back
+        base / "source_1", # rolled back
+        base / "source_3", # untouched
+    }
+    assert renamer.get_log_contents() == "" # the log file is empty
+    rm_tree(base)
 
+
+def test_rename_fail_and_rollback_and_undo():
+    """Undoing a successful rollback is possible, but has no effect."""
+    renamer = Renamer()
+    base = Path("test") / "rollback_path"
+    rm_tree(base)
+    base.mkdir()
+    arcs = [
+        Arc(base / "source_0", base / "target_0"),
+        Arc(base / "source_1", base / "target_1"),
+        Arc(base / "source_2", base / "target_2"),
+        Arc(base / "source_3", base / "target_3"),
+    ]
+    for arc in arcs:
+        arc.source.touch()
+    arcs[2].source.unlink()  # delete a source
+    with pytest.raises(RecoverableRenamingError):
+        renamer.perform_renamings(arcs) # the renaming fails
+    renamer.rollback_renamings() # but we can roll back the previous ones
+    renamer.undo_renamings()
+    assert set(base.iterdir()) == {
+        base / "source_0", # rolled back
+        base / "source_1", # rolled back
+        base / "source_3", # untouched
+    }
+    rm_tree(base)
+
+
+def test_rename_fail_and_rollback_fail():
+    """One renaming fails, and the previous ones fail to be rolled back."""
+    renamer = Renamer()
+    base = Path("test") / "rollback_path"
+    rm_tree(base)
+    base.mkdir()
+    arcs = [
+        Arc(base / "source_0", base / "target_0"),
+        Arc(base / "source_1", base / "target_1"),
+        Arc(base / "source_2", base / "target_2"),
+        Arc(base / "source_3", base / "target_3"),
+    ]
+    for arc in arcs:
+        arc.source.touch()
+    arcs[2].source.unlink()  # delete a source
+    with pytest.raises(RecoverableRenamingError):
+        renamer.perform_renamings(arcs) # the renaming fails
+    arcs[1].target.unlink() # delete a file already renamed
+    with pytest.raises(FileNotFoundError):
+       renamer.rollback_renamings() # the rollback fails
+    print(renamer.get_log_contents())
+    assert renamer.get_log_contents() == "\n".join([
+        "INFO:root:SOURCE:test/rollback_path/source_0",
+        "INFO:root:TARGET:test/rollback_path/target_0",
+        "INFO:root:SOURCE:test/rollback_path/source_1",
+        "INFO:root:TARGET:test/rollback_path/target_1",
+        "WARNING:root:[Errno 2] No such file or directory: 'test/rollback_path/source_2' -> 'test/rollback_path/target_2'",
+        "INFO:root:rollback",
+        "ERROR:root:rollback:[Errno 2] No such file or directory: 'test/rollback_path/target_1' -> 'test/rollback_path/source_1'",
+    ])
+    with pytest.raises(Exception):
+        renamer.undo_renamings() # The previous rollback failed. Undoing is not possible.
+    rm_tree(base)
+
+
+def test_undo_with_empty_log_file():
+    renamer = Renamer()
+    renamer.log_path.write_text("")
+    renamer.undo_renamings() # doesn't raise an exception
 
 if __name__ == "__main__":  # pragma: no cover
     pytest.main(["-qq", __import__("sys").argv[0]])


### PR DESCRIPTION
- The rollbacks are no more automatically triggered in `renamings.py`. They are delegated to the main program, which allows to make them fail in the tests.
- The undo operation can now be rolled back.
- A lot of tests have been added, exploring various scenarii of renaming / rollback / undo.